### PR TITLE
[feature/update-sentry] update sentry to enable sync send, fix tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.2",
     "spiral/boot": "^1.2",
-    "sentry/sdk": "^2.0",
+    "sentry/sdk": "^3.0",
     "spiral/snapshots": "^1.0"
   },
   "require-dev": {

--- a/tests/Sentry/BootloaderTest.php
+++ b/tests/Sentry/BootloaderTest.php
@@ -50,6 +50,6 @@ class BootloaderTest extends TestCase
         $this->assertInstanceOf(Client::class, $client);
 
         /** @var Client $client */
-        $this->assertSame('https://sentry.demo', $client->getOptions()->getDsn());
+        $this->assertSame('https://key@sentry.demo/2', (string)$client->getOptions()->getDsn());
     }
 }


### PR DESCRIPTION
Update sentry lib to 3.0, which enables report sent not only on worker death, adjust tests